### PR TITLE
fix:footerにmainが隠れる問題修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,7 +22,7 @@ header {
 }
 main {
   padding-top: 60px;
-  padding-bottom: 50px;
+  padding-bottom: 60px;
 }
 footer.footer {
   position: fixed;


### PR DESCRIPTION
表題の通り、レスポンシブ対応で、メニュー表示するとフッターの高さが以前より高くなっており、mainが隠れてしまっているためそれを修正。