### PR TITLE
【Fixed】部員一覧に担当メンバー表示追加、登録日削除

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,7 +39,7 @@ module ApplicationHelper
 
   # 自分がメンターを止める場合に警告
   def role_confirm(user)
-    if user.mentor && user == current_user
+    if user.mentor
       {confirm: I18n.t("views.users.confirm.mentor")}
     end
   end

--- a/app/views/groupings/_members.html.erb
+++ b/app/views/groupings/_members.html.erb
@@ -1,0 +1,5 @@
+<% if user.mentor? %>
+  <% user.group&.members&.each do |member| %>
+    <%= content_tag(:span, member.name, class:"tag light-gray") %>
+  <% end %>
+<% end %>

--- a/app/views/groupings/_mentors.html.erb
+++ b/app/views/groupings/_mentors.html.erb
@@ -1,3 +1,3 @@
-<% user.groupings.each do |grouping| %>
+<% user.groupings.includes(:user).each do |grouping| %>
   <%= content_tag(:span, grouping.group.user.name, class:"tag light-gray") %>
 <% end %>

--- a/app/views/groupings/member_change.js.erb
+++ b/app/views/groupings/member_change.js.erb
@@ -1,2 +1,3 @@
 $("#group-member-<%= @user.id %>").html("<%= j(render 'groupings/member_btn', {user: @user}) %>");
-$("#mentor-<%= @user.id %>").html("<%= j(render 'groupings/mentor', {user: @user}) %>");
+$("#mentors-<%= @user.id %>").html("<%= j(render 'groupings/mentors', {user: @user}) %>");
+$("#members-<%= current_user.id %>").html("<%= j(render 'groupings/members', {user: current_user}) %>");

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,20 +22,20 @@
 
   <body>
     <div class="all-container" id="vanta-background">
-    <header>
-      <%= render "shared/header" %>
-    </header>
-    <main>
-      <% flash.each do |key, message| %>
-        <%= content_tag :div, message, class: "alert alert-#{translate_css(key)}" %>
-      <% end %>
-      <div class="container">
-        <%= yield %>
-      </div>
-    </main>
-    <footer class="container-fluid footer">
-      <%= render "shared/footer" %>
-    </footer>
-  </div>
+      <header>
+        <%= render "shared/header" %>
+      </header>
+      <main>
+        <% flash.each do |key, message| %>
+          <%= content_tag :div, message, class: "alert alert-#{translate_css(key)}" %>
+        <% end %>
+        <div class="container">
+          <%= yield %>
+        </div>
+      </main>
+      <footer class="container-fluid footer">
+        <%= render "shared/footer" %>
+      </footer>
+    </div>
   </body>
 </html>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -13,8 +13,8 @@
         <th><%= sort_link(@q, :code, class: "sort-link", id: "sort-user-code") %></th>
         <th><%= sort_link(@q, :mentor, t("views.users.role"), class: "sort-link", id: "sort-user-role") %></th>
         <th><%= User.human_attribute_name(:mentor) %></th>
+        <th><%= User.human_attribute_name(:group_members) %></th>
         <th><%= sort_link(@q, :entered_at, class: "sort-link", id: "sort-user-entered_at") %></th>
-        <th><%= User.human_attribute_name(:created_at) %></th>
       </tr>
     </thead>
     <tbody>
@@ -30,10 +30,12 @@
             <div id=<%= "role-mentor-#{user.id}"%>><%= render "role_btn", user: user %></div>
           </td>
           <td class="middle">
-            <div id=<%= "mentor-#{user.id}"%>><%= render "groupings/mentor", user: user %></div>
+            <div id=<%= "mentors-#{user.id}"%>><%= render "groupings/mentors", user: user %></div>
+          </td>
+          <td class="middle">
+            <div id=<%= "members-#{user.id}"%>><%= render "groupings/members", user: user %></div>
           </td>
           <td class="middle"><%= l(user.entered_at) %></td>
-          <td class="middle"><%= l(user.created_at, format: :medium) %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/users/role_change.js.erb
+++ b/app/views/users/role_change.js.erb
@@ -1,1 +1,2 @@
 $("#role-mentor-<%= @user.id %>").html("<%= j(render 'users/role_btn', {user: @user}) %>");
+$("#members-<%= @user.id %>").html("<%= j(render 'groupings/members', {user: @user}) %>");

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -38,6 +38,7 @@ ja:
         avatar: 写真
         mentor: メンター
         staff: 部員
+        group_members: 担当メンバー
         entered_at: 入職年
         admin: 管理者
         confirmation_sent_at: パスワード確認送信時刻
@@ -139,11 +140,11 @@ ja:
       comment: コメント投稿
       top: トップ
     home:
-      confirm:
-        mentor: 本当にメンターをやめますか?
       index:
         title: ホーム
     users:
+      confirm:
+        mentor: 担当メンバーの設定も削除されます。本当によろしいですか?
       index:
         title: 部員一覧
       profile:

--- a/spec/system/ransack_spec.rb
+++ b/spec/system/ransack_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe :issue, type: :system do
       before do
         visit issues_path
         find("#sort-issue-title").click
-        sleep 0.1
+        sleep 0.2
       end
       it "タイトルの昇順でソートされる" do
         expect(all(".issue-container")[0]).to have_content issue_bob_1st_2015.title

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -279,7 +279,9 @@ RSpec.describe :user, type: :system do
         sign_in mentor
         visit users_path
         expect{
-          find("#btn-role-#{user.id}").click
+          page.accept_confirm {
+            find("#btn-role-#{user.id}").click
+          }
           sleep 0.1
           user.reload
         }.to change{user.mentor}.to(false)


### PR DESCRIPTION
## メイン
- 部員一覧でメンターの行で担当メンバーが見れた方がわかりやすい。-> 追加しました。
  - それに伴いAjax設定しました。
- 登録日はあまり必要性がないため削除しました。
- メンターと部員の役割変更ボタンは、メンターを部員に変えた場合に担当メンバー設定も削除されるため、確認(confirm)が出るよう変更しました。