### PR TITLE
【Fixed】メンターや担当メンバーを色分けして見やすくして

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -122,12 +122,15 @@ a:hover {
 }
 
 /* 色 */
-.light-green {
+.lightgreen {
   background-color: #41b883;
   color: #fff;
 }
-.light-gray {
-  background-color: #ccc;
+.lightpurple {
+  background-color: #aca8ff;
+}
+.orange {
+  background-color: #ffc4a4;
 }
 .blank-danger {
   padding: 5px;
@@ -212,6 +215,10 @@ a:hover {
   color: inherit;
   &:hover {
     text-decoration: none;
+    color: inherit;
+  }
+  .default-container:hover {
+    box-shadow: 2px 2px 5px #000;
   }
 }
 .unread {

--- a/app/views/groupings/_members.html.erb
+++ b/app/views/groupings/_members.html.erb
@@ -1,5 +1,5 @@
 <% if user.mentor? %>
   <% user.group&.members&.each do |member| %>
-    <%= content_tag(:span, member.name, class:"tag light-gray") %>
+    <%= content_tag(:span, member.name, class:"tag lightpurple") %>
   <% end %>
 <% end %>

--- a/app/views/groupings/_mentors.html.erb
+++ b/app/views/groupings/_mentors.html.erb
@@ -1,3 +1,3 @@
 <% user.groupings.includes(:user).each do |grouping| %>
-  <%= content_tag(:span, grouping.group.user.name, class:"tag light-gray") %>
+  <%= content_tag(:span, grouping.group.user.name, class:"tag orange") %>
 <% end %>

--- a/app/views/issues/_issue.html.erb
+++ b/app/views/issues/_issue.html.erb
@@ -21,7 +21,7 @@
     <div class="issue-abst-footer">
       <div class="issue-tag-container">
         <% issue.tags.pluck(:name).each do |tag_name| %>
-          <%= link_to tag_name, redirect_to_current_path(q:{tags_name_eq: tag_name}), class: "tag light-green" %>
+          <%= link_to tag_name, redirect_to_current_path(q:{tags_name_eq: tag_name}), class: "tag lightgreen" %>
         <% end %>
       </div>
       <div class="issue-btn-container flex">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -7,7 +7,7 @@
     <ul class="navbar-nav">
       <% if user_signed_in? %>
         <% if current_user&.admin? %>
-          <li class="nav-item <%= activate_css(:users, :index)%>">
+          <li class="nav-item">
             <%= link_to t("admin.actions.dashboard.title"), rails_admin_path, class:"nav-link" %>
           </li>
         <% end %>

--- a/app/views/users/_member_profile.html.erb
+++ b/app/views/users/_member_profile.html.erb
@@ -22,7 +22,7 @@
           <%= t "views.users.profile.recent_issue"%>(<%= time_ago_in_words recent_issue.created_at %>): <%= link_to recent_issue.title, issue_path(recent_issue) %>(<%= Issue.human_enum_status(recent_issue.status) %>)
         </p>
         <% member_issues.includes(:tags).tags_on(:tags).most_used(5).pluck(:name).each do |tag_name| %>
-          <%= link_to tag_name, redirect_to_current_path(q:{user_id_eq: group_member.id, tags_name_eq: tag_name}), class: "tag light-green" %>
+          <%= link_to tag_name, redirect_to_current_path(q:{user_id_eq: group_member.id, tags_name_eq: tag_name}), class: "tag lightgreen" %>
         <% end %>
       <% else %>
         <h4 class="blank-danger"><%= t("views.blank") %></h4>

--- a/app/views/users/_profile_format.erb
+++ b/app/views/users/_profile_format.erb
@@ -22,7 +22,7 @@
       <p>
         <%= User.human_attribute_name(:mentor) %>:
         <% user.join_groups&.each do |group| %>
-          <span class="tag light-gray"><%= group.user.name %></span>
+          <span class="tag orange"><%= group.user.name %></span>
         <% end %>
       </p>
     <% end %>


### PR DESCRIPTION
## メイン

- 部員一覧表示時に、ヘッダーのサイト管理がアクティブになるエラー修正
- 部員一覧でメンター、担当メンバーが同じバックグランドカラーで見にくいため、色分けしました
- 通知一覧で通知にマウスを当てるとfont-colorが変化するだけだったので、font-color変化をやめて影が変化する設定にしました。この方が、選択していることがわかりやすい。