### PR TITLE
【Fixed】Fix tags

### DIFF
--- a/app/javascript/packs/tags.js
+++ b/app/javascript/packs/tags.js
@@ -1,20 +1,20 @@
 $(document).on('turbolinks:load', function() {
-  Vue.component('multiselect', window.VueMultiselect.default)
   const tagList = $("#app").data("tag-list");
   const myTagList = $("#app").data("my-tag-list");
 
+  Vue.component('multiselect', window.VueMultiselect.default)
   new Vue({
     el: "#app",
     data() {
       return {
-        value: myTagList,
-        options: tagList,
+        tagList: tagList,
+        myTagList: myTagList,
       }
     },
     methods: {
-      addTag (newTag) {
-        this.options.push(newTag)
-        this.value.push(newTag)
+      addTag(newTag) {
+        this.tagList.push(newTag)
+        this.myTagList.push(newTag)
       },
     },
   })

--- a/app/views/issues/_form.html.erb
+++ b/app/views/issues/_form.html.erb
@@ -21,9 +21,9 @@
       <%= form.select :scope, Issue.enum_options_for_select(:scope), {}, class: "custom-select mr-sm-2", require: true %>
       <small class="text-danger"><%= t("views.issues.show.draft_explanation") %></small>
     </div>
-    <%= content_tag(:div, id:"app", data:{tag_list: Issue.tag_counts_on(:tags).pluck(:name).to_json, my_tag_list: issue.tag_list.to_json}) do %>
-      <multiselect v-model="value" tag-placeholder="Add this as new tag" placeholder="Search or add a tag"  :options="options" :multiple="true" :taggable="true" @tag="addTag" id="vue-tag-input"></multiselect>
-      <pre class="language-json" hidden="hidden"><input type="text" name="issue[tag_list]" id="issue_tag_list" v-model="value"></pre>
+    <%= content_tag(:div, id:"app", data:{tag_list: Issue.tag_counts_on(:tags).pluck(:name), my_tag_list: issue.tag_list}) do %>
+      <multiselect v-model="myTagList" tag-placeholder="Add this as new tag" placeholder="Search or add a tag"  :options="tagList" :multiple="true" :taggable="true" @tag="addTag" id="vue-tag-input"></multiselect>
+      <pre class="language-json" hidden="hidden"><input type="text" name="issue[tag_list]" id="issue_tag_list" v-model="myTagList"></pre>
     <% end %>
     <div class="form-group">
       <%= form.label :description, class: "sr-only" %>

--- a/app/views/issues/_issue.html.erb
+++ b/app/views/issues/_issue.html.erb
@@ -20,7 +20,7 @@
     <h4><%= link_to issue.title, issue %></h4>
     <div class="issue-abst-footer">
       <div class="issue-tag-container">
-        <% issue.tags.pluck(:name).each do |tag_name| %>
+        <% issue.tag_list.each do |tag_name| %>
           <%= link_to tag_name, redirect_to_current_path(q:{tags_name_eq: tag_name}), class: "tag lightgreen" %>
         <% end %>
       </div>


### PR DESCRIPTION
## メイン

- タグデータをjson形式でvue.jsへ渡していたが、実は不要だったため、その部分を削除した
- Vue.jsの変数名が分かりにくかったため、jQueryで定義した変数と同じものに変更した
- tags.pluck(:name)よりtag_listの方がメソッドがシンプルなため、変更した。