### PR TITLE
【Fixed】issueのnotifyがただの更新でも動作する問題解決 

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -43,11 +43,12 @@ class Issue < ApplicationRecord
     groups = user.join_groups
     return if scope == "draft" || groups.blank?
     notify_message =
-      if status_change.nil? || scope_change&.dig(0) == "draft"
+      if (updated_at - created_at).round(1) == 0 || scope_change&.dig(0) == "draft"
         Issue.human_attribute_name(:notify_message, issue: title, user: user.name)
       elsif status_change == %w[pending solving]
         Issue.human_attribute_name(:solving_notify_message, issue: title, user: user.name)
       end
+    return unless notify_message
     groups.map do |group|
       notifications.create do |note|
         note.user = group.user

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -74,6 +74,16 @@ RSpec.describe Issue, type: :model do
       end
     end
 
+    context "ユーザーが公開イシューを更新した場合" do
+      it "通知はされない" do
+        issue_release.save
+        sleep 0.1
+        expect{
+          issue_release.update(title: "update")
+        }.to change{Notification.count}.by(0)
+      end
+    end
+
     context "ユーザーが限定イシューを投稿した場合" do
       it "担当メンターに通知が作成され、その他には通知されない" do
         expect{


### PR DESCRIPTION
- close #110 

- 未通知条件
  + 下書きは未通知
  + 担当メンターが存在しない場合未通知
  + 上記の条件以外で、通知条件を満たさない場合、未通知

- 通知条件（未通知条件の上2つを満たさない場合）
  + 作成日時と更新日時が小数点１桁まで一致するものはメッセージを作成。
  + 下書きからscopeが変更の場合通知
  + 未解決から解決の場合通知

としました。
rspecも作成しました。