### PR TITLE
【Fixed】issueのnotifyがただの更新でも動作する問題を再度修正

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -43,7 +43,7 @@ class Issue < ApplicationRecord
     groups = user.join_groups
     return if scope == "draft" || groups.blank?
     notify_message =
-      if (updated_at - created_at).round(1) == 0 || scope_change&.dig(0) == "draft"
+      if scope_change&.dig(0) == "draft" || notifications.blank?
         Issue.human_attribute_name(:notify_message, issue: title, user: user.name)
       elsif status_change == %w[pending solving]
         Issue.human_attribute_name(:solving_notify_message, issue: title, user: user.name)

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -84,6 +84,16 @@ RSpec.describe Issue, type: :model do
       end
     end
 
+    context "ユーザーが公開イシューを何も変更せず更新した場合" do
+      it "通知はされない" do
+        issue_release.save
+        sleep 0.1
+        expect{
+          issue_release.save
+        }.to change{Notification.count}.by(0)
+      end
+    end
+
     context "ユーザーが限定イシューを投稿した場合" do
       it "担当メンターに通知が作成され、その他には通知されない" do
         expect{


### PR DESCRIPTION
- close #110

#111で修正したものが不完全だったため修正

- 未通知条件
  + 下書きは未通知
  + 担当メンターが存在しない場合未通知
  + 上記の条件以外で、通知条件を満たさない場合、未通知

- 通知条件（未通知条件の上2つを満たさない場合）
  + イシューの通知が1件も作成されていない場合
  + 下書きからscopeが変更の場合通知
  + 未解決から解決の場合通知

としました。
rspecも作成しました。