### PR TITLE
【Fiexed】チャット機能のspecテスト追加

### DIFF
--- a/app/channels/chat_room_channel.rb
+++ b/app/channels/chat_room_channel.rb
@@ -14,7 +14,7 @@ class ChatRoomChannel < ApplicationCable::Channel
     Message.create!(
       content: data["message"],
       read: false,
-      user_id: current_user.id,
+      user_id: data["user_id"],
       chat_room_id: data["chat_room_id"]
     )
   end

--- a/app/controllers/chat_rooms_controller.rb
+++ b/app/controllers/chat_rooms_controller.rb
@@ -28,7 +28,7 @@ class ChatRoomsController < ApplicationController
   private
 
   def ensure_correct_user
-    user = User.find(params[:user_id])
-    redirect_back fallback_location: root_path unless current_user == user
+    chat_room = ChatRoom.find(params[:id])
+    redirect_back fallback_location: root_path unless chat_room.users.include?(current_user)
   end
 end

--- a/app/javascript/channels/chat_room_channel.js
+++ b/app/javascript/channels/chat_room_channel.js
@@ -25,8 +25,8 @@ if (/chat_rooms/.test(location.pathname)) {
       }
     },
 
-    speak: function(message, chat_room_id) {
-      return this.perform('speak', {message: message, chat_room_id: chat_room_id});
+    speak: function(message, user_id, chat_room_id) {
+      return this.perform('speak', {message: message, user_id: user_id, chat_room_id: chat_room_id});
     },
 
     read: function(message_id) {
@@ -38,7 +38,8 @@ if (/chat_rooms/.test(location.pathname)) {
     const value = e.target.value;
     if (e.key == "Enter" && value.match(/\S/g)) {
       const chat_room_id = $("textarea").data("chat_room_id");
-      appChatRoom.speak(value, chat_room_id);
+      const user_id = $("textarea").data("user_id");
+      appChatRoom.speak(value, user_id, chat_room_id);
       e.target.value = "";
       e.preventDefault();
     }

--- a/app/views/chat_rooms/show.html.erb
+++ b/app/views/chat_rooms/show.html.erb
@@ -22,7 +22,7 @@
   </div>
 
   <form class="chat_room-message-form container">
-    <textarea data-behavior="chat_room_speaker" data-chat_room_id=<%= @chat_room.id %> placeholder=<%= t("views.chat_rooms.show.message_form") %>
-    class="chat_room-message-form-textarea"></textarea>
+    <textarea data-behavior="chat_room_speaker" data-chat_room_id=<%= @chat_room.id %> data-user_id=<%= current_user.id %> placeholder=<%= t("views.chat_rooms.show.message_form") %>
+    class="chat_room-message-form-textarea" id="message_content"></textarea>
   </form>
 </div>

--- a/spec/channels/chat_room_channel_spec.rb
+++ b/spec/channels/chat_room_channel_spec.rb
@@ -1,5 +1,47 @@
 require 'rails_helper'
 
 RSpec.describe ChatRoomChannel, type: :channel do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let!(:user) { create(:user) }
+  let!(:partner) { create(:user, :seq) }
+  let!(:other) { create(:user, :seq) }
+  let!(:chat_room) { create(:chat_room) }
+  let!(:other_chat_room) { create(:chat_room) }
+  let!(:chat_room_user) { create(:chat_room_user, user: user, chat_room: chat_room) }
+  let!(:chat_room_partner) { create(:chat_room_user, user: partner, chat_room: chat_room) }
+  let!(:chat_room_other) { create(:chat_room_user, user: other, chat_room: other_chat_room) }
+  let!(:chat_room_other_user) { create(:chat_room_user, user: user, chat_room: other_chat_room) }
+
+  describe "メッセージ送信" do
+    let(:message) { attributes_for(:message, user: user) }
+    context "送信成功" do
+      before do
+        # stub_connection current_user: user
+        subscribe(user_id: user.id, chat_room_id: chat_room.id)
+        expect(subscription).to be_confirmed
+      end
+
+      it "メッセージが保存される" do
+        expect do
+          perform :speak, message: message[:content], user_id: user.id, chat_room_id: chat_room.id
+        end.to change(Message, :count).by(1)
+      end
+
+      it "メッセージが接続している自分のチャネルに配信される" do
+        expect do
+          perform :speak, message: message[:content], user_id: user.id, chat_room_id: chat_room.id
+          sleep 0.5
+        end.to have_broadcasted_to([user, chat_room]).with{|data|
+          expect(data["message"].to_s).to include(message[:content])
+        }
+      end
+    end
+
+    context "送信失敗(chat_roomとuserが不明の場合)" do
+      it "メッセージを送信すると保存できない" do
+        expect do
+          perform :speak, message: message[:content], user_id: user.id, chat_room_id: chat_room.id
+        end.to raise_error RuntimeError
+      end
+    end
+  end
 end


### PR DESCRIPTION
- [x] クライアント側からサーバーへmessageの作成者idデータを送信する仕様に変更
- [x] chat roomのアクセス制限が機能していなかったためテスト追加し修正
- [x] チャット機能のspecテスト追加（但し、同時アクセス時の動作確認テストはできていない）

- #116 