### PR TITLE
【Fixed】chatにuser_indexページを追加し、indexはメッセージの作成日降順にソートされるよう設定

### DIFF
--- a/app/controllers/chat_rooms_controller.rb
+++ b/app/controllers/chat_rooms_controller.rb
@@ -3,6 +3,11 @@ class ChatRoomsController < ApplicationController
   before_action :ensure_correct_user, only: %i[show]
 
   def index
+    chat_room_ids = ChatRoomUser.where(user_id: current_user.id).pluck(:chat_room_id)
+    @chat_rooms = ChatRoom.where(id: chat_room_ids).joins(:messages).includes(:messages).distinct(true).order("messages.created_at desc")
+  end
+
+  def user_index
     @users = User.where.not(id: current_user.id).with_attached_avatar.order_by_code
   end
 

--- a/app/views/chat_rooms/_chat_room_nav.html.erb
+++ b/app/views/chat_rooms/_chat_room_nav.html.erb
@@ -1,0 +1,4 @@
+<nav class="nav nav-pills btn2-container">
+    <%= link_to "チャット", user_chat_rooms_path(current_user), class: "flex-fill text-center nav-link #{activate_css(:chat_rooms, :index)}" %>
+    <%= link_to "部員一覧", user_index_user_chat_rooms_path(current_user), class: "flex-fill text-center nav-link #{activate_css(:chat_rooms, :user_index)}" %>
+</nav>

--- a/app/views/chat_rooms/index.html.erb
+++ b/app/views/chat_rooms/index.html.erb
@@ -1,26 +1,28 @@
 <div class="chat_room-index-page">
   <div class="chat_users-container">
     <h3 class="chat_users-title ml-3">
-      <%= ChatRoom.human_attribute_name(:chat) %>&#x1f605
+      <%= render "chat_room_nav" %>
     </h3>
     <div class="chat_users-list">
-      <% if @users.present? %>
-        <% @users.each do |user| %>
+      <% if @chat_rooms.present? %>
+        <% @chat_rooms.each do |chat_room| %>
+          <% chat_room_user = ChatRoomUser.where.not(user_id: current_user.id).where(chat_room_id: chat_room.id).first %>
+          <% user = User.find(chat_room_user.user_id) %>
           <%= link_to user_chat_rooms_path(user_id: user.id), method: :post do %>
-          <div class="chat_users-person">
-            <%= image_tag prepare_avatar(user), class: "avatar50" %>
-            <div class="chat_users-person-profile">
-              <div class="chat_users-person-profile-name">
-                <span><%= user.code %></span>
-                <span><%= user.name %></span>
-              </div>
-              <div class="d-flex">
-                <% unread_counts = unread_messages_count(user) %>
-                <span class=<%= unread_counts_css(unread_counts) %>><%= unread_counts %></span>
-                <span class="current-message <%= unread_messages_css(unread_counts)%>"><%= current_message(user)&.content %></span>
+            <div class="chat_users-person">
+              <%= image_tag prepare_avatar(user), class: "avatar50" %>
+              <div class="chat_users-person-profile">
+                <div class="chat_users-person-profile-name">
+                  <span><%= user.code %></span>
+                  <span><%= user.name %></span>
+                </div>
+                <div class="d-flex">
+                  <% unread_counts = unread_messages_count(user) %>
+                  <span class=<%= unread_counts_css(unread_counts) %>><%= unread_counts %></span>
+                  <span class="current-message <%= unread_messages_css(unread_counts)%>"><%= current_message(user)&.content %></span>
+                </div>
               </div>
             </div>
-          </div>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/chat_rooms/user_index.erb
+++ b/app/views/chat_rooms/user_index.erb
@@ -1,0 +1,31 @@
+<div class="chat_room-index-page">
+  <div class="chat_users-container">
+    <h3 class="chat_users-title ml-3">
+      <%= render "chat_room_nav" %>
+    </h3>
+    <div class="chat_users-list">
+      <% if @users.present? %>
+        <% @users.each do |user| %>
+          <%= link_to user_chat_rooms_path(user_id: user.id), method: :post do %>
+          <div class="chat_users-person">
+            <%= image_tag prepare_avatar(user), class: "avatar50" %>
+            <div class="chat_users-person-profile">
+              <div class="chat_users-person-profile-name">
+                <span><%= user.code %></span>
+                <span><%= user.name %></span>
+              </div>
+              <div class="d-flex">
+                <% unread_counts = unread_messages_count(user) %>
+                <span class=<%= unread_counts_css(unread_counts) %>><%= unread_counts %></span>
+                <span class="current-message <%= unread_messages_css(unread_counts)%>"><%= current_message(user)&.content %></span>
+              </div>
+            </div>
+          </div>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<%= javascript_pack_tag 'notify' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,11 @@ Rails.application.routes.draw do
           delete :destroy_all
         end
       end
-      resources :chat_rooms, only: %i[index show create]
+      resources :chat_rooms, only: %i[index show create] do
+        collection do
+          get :user_index
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## メイン
- chatにuser_indexページを追加。送信相手である部員一覧を表示
- indexにはチャットルームが存在し、メッセージが一度でも送信されたものを表示
- indexはメッセージの作成日降順にソートされるよう設定
- rspec追加
- #116 