### PR TITLE
【Fixed】EC2でaction cableが使用できるよう設定

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,5 +1,5 @@
 # server-based syntax
-server "18.177.55.146", user: "app", roles: %w{app db web}
+server ENV['HTTP_HOST'], user: "app", roles: %w{app db web}
 
 # Global options
 set :ssh_options, keys: '/Users/fumta/.ssh/id_rsa'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,8 +40,11 @@ Rails.application.configure do
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil
+  if ENV['DISABLE_REQUEST_FORGERY_PROTECTION'] == "true"
+    config.action_cable.disable_request_forgery_protection = true
+  end
   config.action_cable.url = "wss://#{ENV['HTTP_HOST']}/cable"
-  config.action_cable.allowed_request_origins = ["https://#{ENV['HTTP_HOST']}", "http://#{ENV['HTTP_HOST']}/"]
+  config.action_cable.allowed_request_origins = ["https://#{ENV['HTTP_HOST']}", "http://#{ENV['HTTP_HOST']}"]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true


### PR DESCRIPTION
- 環境変数によって
config.action_cable.disable_request_forgery_protection = true
が設定されるように変更。