### PR TITLE
[None]sendgridを修復

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'kaminari'
 gem 'rails_admin'
 gem 'ransack'
 gem 'rexml'
+gem 'sendgrid-ruby'
 gem 'unicorn'
 gem 'whenever', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -317,6 +317,7 @@ GEM
     rspec-support (3.12.0)
     ruby-vips (2.1.4)
       ffi (~> 1.12)
+    ruby_http_client (3.5.5)
     rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -333,6 +334,8 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     semantic_range (3.0.0)
+    sendgrid-ruby (6.6.2)
+      ruby_http_client (~> 3.4)
     spring (2.1.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -439,6 +442,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (>= 6)
   selenium-webdriver
+  sendgrid-ruby
   spring
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@
 ## インフラ
 
 - AWS S3
-- Heroku
 - SendGrid
 - docker
 
@@ -48,6 +47,7 @@
 - rails_admin
 - ransack
 - rspec-rails
+- sendgrid-ruby
 - whenever
 
 ### javascript
@@ -95,7 +95,7 @@
 以下は全てターミナルでの操作になります。
 最初にアカウント登録したユーザーに管理者権限が付与されます。
 
-```
+```plain text
 $ git clone https://github.com/fumtas1k/issues_app.git
 $ cd issues_app
 $ docker-compose up
@@ -103,14 +103,28 @@ $ docker-compose up
 
 issues_db, issues_web, issues_webpackerが起動した後、新たなターミナルで以下を実行
 
-```
+```plain text
 $ docker-compose run web rails db:create db:migrate
 ```
 
-ダミーデータが欲しい場合は、以下を実行
+環境変数は`issues_app`ディレク直下に`.env`ファイルを作成し、以下を埋めて下さい。`SENDGRID_API_KEY`はSEND GRIDに登録し、API KEYを入手して下さい（メール登録しなくても使用可能です）。EMAILはご自分のメールアドレスを入力して下さい。
 
+```plain text
+SENDGRID_API_KEY =
+SENDGRID_API_HOST = https://api.sendgrid.com
+EMAIL =
 ```
+
+ダミーデータが欲しい場合は、ターミナルで以下を実行
+
+```plain text
 $ docker-compose run web rails db:seed
+```
+
+dockerのwebサーバー内で作業したい場合は、ターミナルで以下を実行
+
+```plain text
+$ docker-compose exec -it web bush
 ```
 
 ## カタログ設計

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,18 +63,10 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "issues_app_production"
 
-  config.action_mailer.perform_caching = false
-  config.action_mailer.default_url_options = { host: 'https://warm-scrubland-25965.herokuapp.com' }
-  ActionMailer::Base.delivery_method = :smtp
-  ActionMailer::Base.smtp_settings = {
-    user_name: ENV['SENDGRID_USERNAME'],
-    password: ENV['SENDGRID_PASSWORD'],
-    domain: "heroku.com",
-    address: "smtp.sendgrid.net",
-    port: 587,
-    authentication: :plain,
-    enable_starttls_auto: true
-  }
+  config.action_mailer.delivery_method = :sendgrid
+  config.action_mailer.perform_caching = true
+  config.action_mailer.default_url_options = { host: ENV['HTTP_HOST'] }
+
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/initializers/sendgrid.rb
+++ b/config/initializers/sendgrid.rb
@@ -1,0 +1,5 @@
+require 'mail/send_grid'
+
+Rails.configuration.to_prepare do
+  ActionMailer::Base.add_delivery_method :sendgrid, Mail::SendGrid, api_key: ENV['SENDGRID_API_KEY']
+end

--- a/lib/mail/send_grid.rb
+++ b/lib/mail/send_grid.rb
@@ -1,0 +1,48 @@
+class Mail::SendGrid
+
+  # settingsにはsendgrid.rbで渡したapi_keyが格納されている
+  # 下記プライベートメソッドのset_api_hostで取得した値も追加しておき、API呼び出し時に引数として渡す
+  def initialize(settings)
+    settings[:api_host] = set_api_host
+    @settings = settings
+  end
+
+  def deliver!(mail)
+    # ActionMailerのメイラー内で作成したメールオブジェクトの詳細情報をSendGrid用のメールオブジェクトに置き換えていく
+    # personalizationでto, cc, bccを設定
+    personalization = SendGrid::Personalization.new
+    personalization.subject = mail.subject
+
+    Array(mail.to).each do |email|
+      personalization.add_to(::SendGrid::Email.new(email: email))
+    end
+
+    Array(mail.cc).each do |email|
+      personalization.add_cc(::SendGrid::Email.new(email: email))
+    end
+
+    Array(mail.bcc).each do |email|
+      personalization.add_bcc(::SendGrid::Email.new(email: email))
+    end
+
+    # from, subject, content, personalizationを設定しSendGrid用のメールオブジェクト完成
+    sg_mail = ::SendGrid::Mail.new
+    sg_mail.from = ::SendGrid::Email.new(email: mail.from.first)
+    sg_mail.subject = mail.subject
+    sg_mail.add_content(::SendGrid::Content.new(type: "text/plain", value: mail.body.raw_source))
+    sg_mail.add_personalization(personalization)
+
+    # API呼び出し
+    sg = ::SendGrid::API.new(api_key: @settings[:api_key], host: @settings[:api_host])
+    response = sg.client.mail._("send").post(request_body: sg_mail.to_json)
+    puts response.status_code
+    puts response.headers
+  end
+
+  private
+
+  # API接続先のホストを取得する
+  def set_api_host
+    ENV["SENDGRID_API_HOST"]
+  end
+end


### PR DESCRIPTION
## 対応内容

sendGridによるメール配信がherokuのadd-onに依存していたため現在使用不可。

- [x] sendgrid-rubyのgemをインストール
- [x] 設定変更