### PR TITLE
[change]primary key をULIDに変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'ransack'
 gem 'redis', '~> 4'
 gem 'rexml'
 gem 'sendgrid-ruby'
+gem 'ulid'
 gem 'unicorn'
 gem 'whenever', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -366,6 +366,7 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (1.2.11)
       thread_safe (~> 0.1)
+    ulid (1.3.0)
     unicorn (6.1.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -450,6 +451,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)
   tzinfo-data
+  ulid
   unicorn
   web-console (>= 3.3.0)
   webdrivers

--- a/app/models/concerns/ulid_pk.rb
+++ b/app/models/concerns/ulid_pk.rb
@@ -1,0 +1,13 @@
+require 'ulid'
+
+module UlidPk
+  extend ActiveSupport::Concern
+
+  included do
+    before_create :set_ulid
+  end
+
+  def set_ulid
+    self.id = ULID.generate
+  end
+end


### PR DESCRIPTION
## 対応内容

- [ ] userのPKをulidに変更
- [ ] 関連するテーブルのFKをulidに変更

## 問題点

taggingsのgem等、対応するid部分がすべてbigintとなっており、変更するにはuser関連のidだけでなく、すべてのモデルのid及びFKをstring or binaryに変更しないといけない。今から変更するのは現実的ではない。